### PR TITLE
Update rental to 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
 
 [[package]]
 name = "rental"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
+checksum = "cc89fe2acac36d212474d138aaf939c04a82df5b61d07011571ebce5aef81f2e"
 dependencies = [
  "rental-impl",
  "stable_deref_trait",


### PR DESCRIPTION
Your crate depends on an old version of `rental`, which relies on a backwards-compatibiltiy hack in rustc. In future versions of rustc, versions of `rental` below `0.5.6` will now compiling, breaking your crate.

This PR updates your crate to `rental` 0.5.6, which ensures that it will continue to compile with both older and newer version of rustc.

For more information, see https://github.com/rust-lang/rust/issues/83125